### PR TITLE
Implement VAO for terrain rendering

### DIFF
--- a/shaders/terrain.frag
+++ b/shaders/terrain.frag
@@ -9,7 +9,7 @@ in vec3 worldNormal;
 
 // Uniforms from cpp
 uniform vec4 light_direction;
-uniform vec4 ambiant_color;
+uniform vec4 ambient_color;
 uniform sampler2D texture2d;
 
 //Outputs for GPU
@@ -21,7 +21,7 @@ void main(void)
 
     vec3 baseColor = vec3(1.0, 1.0, 1.0);
 
-    vec3 ambient = ambiant_color.rgb;
+    vec3 ambient = ambient_color.rgb;
     vec3 diffuseColor = diffuse * baseColor * 0.8;
 
     vec4 texColor = texture(texture2d, vTexCoord.st);

--- a/srcs/gui/OpenGLWidget.hpp
+++ b/srcs/gui/OpenGLWidget.hpp
@@ -16,6 +16,8 @@
 # include <iostream>
 # include <QOpenGLBuffer>
 # include <QOpenGLShaderProgram>
+# include <QOpenGLVertexArrayObject>
+
 # define SIZE_MAP 5.0
 
 class OpenGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
@@ -28,10 +30,10 @@ public:
 	void resizeGL(int width, int height) override;
 	void paintGL() override;
 
-	void drawGizmo(QMatrix4x4 &mvpMatrix);
+	void drawGizmo();
 
 	void initializeUVMap();
-	void initializeBuffers();
+	void initializeVAO();
 	void initializeShaders();
 
 	void refreshMVPMatrix();
@@ -46,55 +48,61 @@ public:
 	void mouseMoveEvent(QMouseEvent *event) override;
 	void rotateBy(int x, int y, int z);
 
-	float	distance;
-	float	xRot;
-	float	yRot;
-	float	zRot;
-	float	xTrans;
-	float	yTrans;
-	float	zTrans;
-	QPoint	lastPos;
 public slots:
 	virtual void timeOutSlot();
+
 private:
-	QTimer		timer;
-	QTime		timeLastFrame;
-	int			frameCount;
-	int			lastCount;
-	int			delay;
+	// FPS Counter
+	QPoint	lastPos;
+	QTime	timeLastFrame;
+	QTimer	timer;
+	int		delay;
+	int		frameCount;
+	int		lastCount;
 
-	Map				vertices;
-	QString			modeName[4] = {
-		"Shaders drawing",
-		"Buffers drawing"
-	};
+	// MVP Matrix
+	QMatrix4x4	mvpMatrix;
+	float		distance;
+	float		xRot;
+	float		yRot;
+	float		zRot;
+	float		xTrans;
+	float		yTrans;
+	float		zTrans;
+
+	// Light animation
+	bool	animation;
+	float	light_alpha;
+
+	// Rendering Mode
+	QString				renderingMode[2] = {"Shaders drawing", "Buffers drawing"};
 	enum eRenderingMode	{SHADERS, BUFFERS};
-
 	eRenderingMode		mode;
 	int					fillMode;
+
+	// Mesh
+	Map					vertices;
 	Triangulator		indexArray;
 	QVector<QVector2D>	UVMap;
-
-	QMatrix4x4			mvpMatrix;
-
-	QOpenGLBuffer		vertexBuffer;
-	QOpenGLBuffer		indexBuffer;
-	QOpenGLBuffer		normalBuffer;
-	QOpenGLBuffer		textureBuffer;
-
-	QOpenGLTexture		*texture;
-
 	QVector<QVector3D>	normales;
 
-	//Shader zone
+	// Mesh Rendering
+	QOpenGLVertexArrayObject	terrainVAO;
+	QOpenGLBuffer				vertexBuffer;
+	QOpenGLBuffer				indexBuffer;
+	QOpenGLBuffer				textureBuffer;
+	QOpenGLBuffer				normalBuffer;
+
+	// Shaders and Attributes and Uniforms location
 	QOpenGLShaderProgram	program;
 	int						matrixLocation;
 	int						textureLocation;
-
+	int						lightDirectionLocation;
+	int						ambientColorLocation;
 	enum eAttributeLocation	{ vertexAttribute, normalAttribute, textureAttribute};
 
-	bool					animation = false;
-	float					light_alpha = 0;
+	// Texture handling
+	QOpenGLTexture	*texture;
 };
 
 #endif //TEST_HPP


### PR DESCRIPTION
This pull request introduces several updates to the OpenGL rendering system, focusing on improving the structure, performance, and maintainability of the code. The key changes include replacing the manual buffer initialization with a Vertex Array Object (VAO), fixing a typo in the shader uniform name, and enhancing the handling of rendering modes and animations. Additionally, the code has been refactored to improve readability and reduce redundancy.

### Shader Updates:
* Fixed a typo in the shader uniform name by renaming `ambiant_color` to `ambient_color` in both the uniform declaration and its usage. (`shaders/terrain.frag`)

### Rendering System Enhancements:
* Replaced manual buffer initialization with a VAO in `initializeVAO`, simplifying buffer management and improving performance. (`srcs/gui/OpenGLWidget.cpp`)
* Updated `drawShaders` to bind and release the VAO instead of manually enabling/disabling individual buffers. (`srcs/gui/OpenGLWidget.cpp`)
* Removed the obsolete `initializeBuffers` method, consolidating buffer initialization into `initializeVAO`. (`srcs/gui/OpenGLWidget.cpp`)

### User Interaction Improvements:
* Refactored key event handling in `keyPressEvent` to use `else if` for better readability and added a fallback case for unhandled keys. (`srcs/gui/OpenGLWidget.cpp`)
* Adjusted `rotateBy` to scale rotation increments for smoother user input handling. (`srcs/gui/OpenGLWidget.cpp`)

### Code Cleanup and Refactoring:
* Replaced `modeName` with `renderingMode` for better clarity in rendering mode descriptions. (`srcs/gui/OpenGLWidget.cpp`, `srcs/gui/OpenGLWidget.hpp`)
* Simplified the `drawGizmo` method by removing the unused `mvpMatrix` parameter. (`srcs/gui/OpenGLWidget.cpp`, `srcs/gui/OpenGLWidget.hpp`)